### PR TITLE
Changes specific for service-web-formats project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+.idea/

--- a/tslib.js
+++ b/tslib.js
@@ -69,7 +69,7 @@ var __classPrivateFieldSet;
         d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
     };
 
-    __assign = Object.assign || function (t) {
+    __assign = function (t) {
         for (var s, i = 1, n = arguments.length; i < n; i++) {
             s = arguments[i];
             for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p)) t[p] = s[p];


### PR DESCRIPTION
- Remove usage of `Object.assign` when defining the `__assign` helper.